### PR TITLE
[nrf52840] radio: rand() should not be used from an ISR, replaces with rand_r() and externally provided seed for now

### DIFF
--- a/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_csma_ca.c
+++ b/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_csma_ca.c
@@ -34,6 +34,8 @@
  *
  */
 
+#define _POSIX_C_SOURCE // make sure that POSIX rand_r() is declared
+
 #include "nrf_802154_csma_ca.h"
 
 #include <assert.h>
@@ -139,6 +141,7 @@ static void frame_transmit(void * p_context)
  */
 static void random_backoff_start(void)
 {
+    assert(nrf_802154_csma_ca_random_seed != 0);
     uint8_t backoff_periods = rand_r(&nrf_802154_csma_ca_random_seed) % (1 << m_be);
 
     m_timer.callback  = frame_transmit;

--- a/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_csma_ca.c
+++ b/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_csma_ca.c
@@ -57,6 +57,8 @@ static const uint8_t    * mp_psdu;      ///< Pointer to PSDU of the frame being 
 static nrf_802154_timer_t m_timer;      ///< Timer used to back off during CSMA-CA procedure.
 static bool               m_is_running; ///< Indicates if CSMA-CA procedure is running.
 
+unsigned int nrf_802154_csma_ca_random_seed = 0; ///< Random seed used for backoff timeout calculation. NOTE: needs to be externally initialized!
+
 /**
  * @brief Perform appropriate actions for busy channel conditions.
  *
@@ -137,7 +139,7 @@ static void frame_transmit(void * p_context)
  */
 static void random_backoff_start(void)
 {
-    uint8_t backoff_periods = rand() % (1 << m_be);
+    uint8_t backoff_periods = rand_r(&nrf_802154_csma_ca_random_seed) % (1 << m_be);
 
     m_timer.callback  = frame_transmit;
     m_timer.p_context = NULL;

--- a/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_csma_ca.h
+++ b/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_csma_ca.h
@@ -44,6 +44,8 @@
  * @brief CSMA-CA procedure.
  */
 
+extern unsigned int nrf_802154_csma_ca_random_seed;
+
 /**
  * @brief Start CSMA-CA procedure for transmission of given frame.
  *


### PR DESCRIPTION
`rand()` when called from an ISR will attempt to allocate `_reent` struct from heap for thread safety, which shouldn't happen in the interrupt context.

This PR replaces `rand()` call to `rand_r()` and delegates seed generation to something else.

**This is a stop-gap solution for now, I'm going to report this issue to OpenThread/Nordic on Monday,  so that they can come up with something that doesn't require the seed to be provided externally**